### PR TITLE
considering a second optional input format 

### DIFF
--- a/bin/extract_sequences.py
+++ b/bin/extract_sequences.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3 
+import os, sys
+from Bio import SeqIO
+import re
+import argparse
+from glob import glob 
+
+
+def init_parser():
+	parser = argparse.ArgumentParser(description="Concatenate sequences from files.")
+	group = parser.add_mutually_exclusive_group(required=True)
+	group.add_argument("-s", "--segment", default='NONE', type=str, help="Input folder containing one consensus.fa per isolate, with up to 8 segments per file.")
+	group.add_argument("-c", "--concat", action='store_true', help="Input folder containing one consensus.fa per isolate, with up to 8 segments per file.")
+	
+	parser.add_argument("-i", "--inpath",  help="Input folder containing one consensus.fa per isolate, with up to 8 segments per file.")
+	parser.add_argument('-o', "--outpath", type=str, required=True, help="Output file name")
+	
+	return parser
+
+def concatenate_sequences(filepath):
+	sequences = list(SeqIO.parse(filepath, "fasta"))
+	
+	if len(sequences) == 8:
+		concatenated_seq = sequences[0]
+		for seq in sequences[1:]:
+			concatenated_seq += seq
+
+		# rename sequences
+		concatenated_seq.id = re.split("_fluviewer|_segment", sequences[0].id)[0]
+		concatenated_seq.name = concatenated_seq.id
+		concatenated_seq.description = concatenated_seq.id
+		return concatenated_seq
+	
+	print(f"WARN: Skipping {filepath}. Segment sequences are missing")
+
+	return None
+
+def extract_sequences(filepath, target_segment):
+	sequences = list(SeqIO.parse(filepath, "fasta"))
+
+	for seq in sequences:
+		segment_search = re.search("(?:_fluviewer\||_segment\d_)([A-Z0-9]+)", seq.id)
+
+		if segment_search and segment_search.group(1) == target_segment:
+			return seq
+
+	print(f"WARN: Skipping {filepath}. Could not find segment of interest.")
+	return None
+
+def main(args):
+
+	if os.path.isfile(args.inpath):
+		print("ERROR: Expected directory of consensus.fa files as input.", file=sys.stderr)
+		exit(1)
+	
+	filepaths = glob(os.path.join(args.inpath, '*consensus*'))
+
+	if args.concat:
+		output_sequences = []
+		for filepath in filepaths:
+			concatenated_seq = concatenate_sequences(filepath)
+			if concatenated_seq:
+				output_sequences.append(concatenated_seq)
+
+
+	else:
+		output_sequences = []
+		for filepath in filepaths:
+			extracted_seq = extract_sequences(filepath, args.segment)
+			if extracted_seq:
+				output_sequences.append(extracted_seq)
+
+	SeqIO.write(output_sequences, args.outpath, "fasta")
+
+if __name__ == "__main__":
+	args = init_parser().parse_args()
+	main(args)

--- a/bin/fix_aa_muts.py
+++ b/bin/fix_aa_muts.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import os, json
+import argparse
+
+
+def init_parser():
+	parser = argparse.ArgumentParser()
+	parser.add_argument( 'json',  help='aa_muts.json produced by the Augur translate step')	
+	parser.add_argument( 'outpath',  help='Fixed amino acid mutation node data in JSON format.')	
+	
+	return parser
+
+
+def main(args):
+
+	with open(args.json, 'r') as infile:
+		data = json.load(infile)
+
+
+	name = data['annotations']['HA']['seqid']
+
+	data['annotations']['nuc'] = {
+      "end": 13590,
+      "seqid": name,
+      "start": 1,
+      "strand": "+",
+      "type": "source"
+    }
+
+	with open(args.outpath, 'w') as outfile:
+		json.dump(data, outfile, indent=4)
+
+if __name__ == "__main__":
+	args = init_parser().parse_args()
+	main(args)

--- a/nextflow.config
+++ b/nextflow.config
@@ -79,7 +79,7 @@ process {
 
 profiles {
     conda {
-      process.conda = "${projectDir}/environments/environment.yml"
+      process.conda = "${projectDir}/environments/ENV.yml"
       conda.createTimeout = '1 h'
       if (params.conda_cache) {
          conda.cacheDir = params.conda_cache

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,44 +11,53 @@ manifest {
 
 params {
 
-//help message
-help = null
+  //help message
+  help = null
 
-//version number
-version = null
+  //version number
+  version = null
 
-//conda env local cache
-conda_cache = null 
+  //conda env local cache
+  conda_cache = null 
 
-//directory containing config/ & data/ folders
-work_dir = "/path/to/data/"
+  //directory containing config/ & data/ folders
+  work_dir = "/path/to/data/"
 
-//reference for alignment
-ref = "${params.work_dir}config/Ref.gb"
+  //reference for alignment
+  ref = "${params.work_dir}/config/Ref.gb"
 
-//input sequences
-seqs = "${params.work_dir}data/sequences.fasta"
+  //reference annotation (needed for concatenated workflow only)
+  ref_anno = "${params.work_dir}/config/Ref.gff3"
 
-//metadata of input sequences
-meta = "${params.work_dir}data/metadata.csv"
+  //input sequences
+  seqs = "${params.work_dir}/data/sequences.fasta"
 
-//strains that are excluded
-drop_strains = "${params.work_dir}config/dropped_strains.txt"
+  //metadata of input sequences
+  meta = "${params.work_dir}/data/metadata.csv"
 
-//colors used in final auspice visualization
-colors = "${params.work_dir}config/colors.csv"
+  //strains that are excluded
+  drop_strains = "${params.work_dir}/config/dropped_strains.txt"
 
-//latitude and longitudes
-lat_long = "${params.work_dir}config/lat_longs.csv"
+  //colors used in final auspice visualization
+  colors = "${params.work_dir}/config/colors.csv"
 
-//details for auspice visualization
-auspice = "${params.work_dir}config/auspice_config.json"
+  //latitude and longitudes
+  lat_long = "${params.work_dir}/config/lat_longs.csv"
 
-//refining phylogeny
-divergence_units = "mutations"
+  //details for auspice visualization
+  auspice = "${params.work_dir}/config/auspice_config.json"
 
-//env variable AUGUR_RECURSION_LIMIT
-recursion_limit = 10000
+  //refining phylogeny
+  divergence_units = "mutations"
+
+  //run workflow for concatenated sequences instead of single segment
+  concat = false
+
+  //if not NONE, automate the extraction of a specific segment from fluviewer_consensus.fa files
+  segment = 'NONE'
+
+  //env variable AUGUR_RECURSION_LIMIT
+  recursion_limit = 10000
 
 }
 
@@ -56,12 +65,12 @@ recursion_limit = 10000
 //the process section of the config file. ex. AWS, SLURM, sun grid engine:
 
 process {
-withName: align {
-    cpus = 28
+  withName: align {
+      cpus = 28
+    }
+  withName: tree {
+      cpus = 28
   }
-withName: tree {
-    cpus = 28
- }
 //  penv='smp'
 //  executor='sge'
 //  memory='30 GB'
@@ -70,7 +79,7 @@ withName: tree {
 
 profiles {
     conda {
-      process.conda = "${projectDir}/environments/ENV.yml"
+      process.conda = "${projectDir}/environments/environment.yml"
       conda.createTimeout = '1 h'
       if (params.conda_cache) {
          conda.cacheDir = params.conda_cache
@@ -83,17 +92,17 @@ profiles {
 //html displaying breakdown of time taken to execute workflow
 timeline {
   enabled = true
-  file = "${params.work_dir}reports/fluflo_timeline.html"
+  file = "${params.work_dir}/reports/fluflo_timeline.html"
 }
 
 //html of cpu/mem usage
 report {
   enabled = true
-  file = "${params.work_dir}reports/fluflo_usage.html"
+  file = "${params.work_dir}/reports/fluflo_usage.html"
 }
 
 //dag of beast-flow workflow
 dag {
     enabled = true
-    file = "${params.work_dir}reports/fluflo_dag.html"
+    file = "${params.work_dir}/reports/fluflo_dag.html"
 }


### PR DESCRIPTION
Added functionality to allow this pipeline to accept a directory of `*consensus.fa` files, one per isolate, as an optional input format. Using a directory under the `--seqs` flag with either the `--concat` or `--segment` flag present will automatically handle the preparation of the multifasta. With neither of "concat" or "segment" present,  the original multifasta input is expected as normal. 

I am still pretty uncertain about whether this is a good design choice. Created an issue to share my thoughts and reasons. Would welcome feedback!