### PR TITLE
Add ability to alter number/method of iterations

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -110,11 +110,11 @@ process tree {
 
   output:
   path("aligned.fasta.treefile")
-
+  
   """
   iqtree -alninfo \
   -ninit 10 \
-  -n 10 \
+  ${params.bootstrap} \
   -me 0.05 \
   -nt ${task.cpus} \
   -s ${aln} \

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,6 +32,10 @@ params {
   //use a specific root for the tree
   root_name = false
 
+  //number of ultrafast bootstraps iq-tree (a command related to iterations;
+  // ex. -n 10 for FAST mode, -b 1000 for nonparametric bootstrap, -B 1000 for Ultrafast bs)
+  bootstrap = "-n 10"
+
   //input sequences
   seqs = "${params.work_dir}/data/sequences.fasta"
 


### PR DESCRIPTION
Adds a parameter to be able to specify the type/ number of iterations during iqtree build. 
Ex. "-b 1000" performs 1000 iterations of nonparametric bootstrapping or "-n 10" would be 10 iterations/ FAST mode or "-B 100" for ultrafast bootstrapping. Fixes #11 . 