### PR TITLE
Add ability to bootstrap in IQ-TREE process

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -248,10 +248,11 @@ workflow {
   if (!ref_gb_format && params.ref_anno == 'NO_FILE' ){                         // Cannot have an empty --ref_anno parameter if reference is in non-GenBank format
     error "ERROR: Parameter --ref_anno (.gff3 or .gb format) must be specified if non-GenBank formatted reference is provided under --ref."
   }
-  if (params.ref_anno != 'NO_FILE' && !(params.ref_anno =~ /.+\.gff.?|.+\.[Gg]b/) ){     // Can only have .gff or .gb formats in the --ref_anno parameter
+  if (params.ref_anno != 'NO_FILE' && !(params.ref_anno =~ /.+\.gff.?|.+\.[Gg]b/) ){     
     error "ERROR: Parameter --ref_anno must be in either .gff or .gb (GenBank) format."
   }
-  
+  // Can only have .gff or .gb formats in the --ref_anno parameter
+
   // Load the ref_anno_ch channel appropriately 
   if (ref_gb_format){                                                         // Copy the ref_ch channel if in GenBank format (ref_ch can be reused as ref_anno_ch)
     ref_anno_ch = ref_ch
@@ -268,7 +269,8 @@ workflow {
   
   ch_aa_muts = translate.out
 
-  if (params.ref_anno != 'NO_FILE' && params.ref_anno =~ /.+\.gff.?/ ) {        // If gff annotation format used, augur translate outputs need to be fixed (causes downstream schema error)
+// If gff annotation format used, augur translate outputs need to be fixed - causes downstream schema error
+  if (params.ref_anno != 'NO_FILE' && params.ref_anno =~ /.+\.gff.?/ ) {        
     ch_aa_muts = fix_aa_json(ch_aa_muts.combine(ancestral.out))
   }
   export(refine.out.combine(ancestral.out).combine(ch_aa_muts), meta_ch, config_ch)

--- a/main.nf
+++ b/main.nf
@@ -102,7 +102,7 @@ process align {
 }
 
 process tree {
-  tag "Building IQTREE - GTR+I+R method - 10 iterations - FAST mode"
+  tag "Building IQTREE - model: ${params.sub_model} - iterations: ${params.bootstrap}"
   publishDir "${params.work_dir}/results/", mode: 'copy'
 
   input:

--- a/main.nf
+++ b/main.nf
@@ -109,7 +109,8 @@ process tree {
   file(aln)
 
   output:
-  path("aligned.fasta.treefile")
+  path("aligned.fasta.treefile"), emit: treefile
+  path("aligned.fasta.contree"), optional: true, emit: contree
   
   """
   iqtree -alninfo \
@@ -260,7 +261,8 @@ workflow {
 
   align(seq_ch.combine(ref_ch)) | tree
   msa_ch = align.out
-  refine(tree.out.combine(msa_ch).combine(meta_ch))
+  tree_ch = tree.out.contree.ifEmpty(tree.out.treefile)
+  refine(tree_ch.combine(msa_ch).combine(meta_ch))
   ancestral(refine.out.combine(msa_ch))
   translate(ancestral.out.combine(refine.out).combine(ref_anno_ch))
   

--- a/main.nf
+++ b/main.nf
@@ -119,7 +119,7 @@ process tree {
   -me 0.05 \
   -nt ${task.cpus} \
   -s ${aln} \
-  -m GTR+I+R 
+  -m ${params.sub_model}
   """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -34,6 +34,7 @@ params {
 
   //number of ultrafast bootstraps iq-tree (a command related to iterations;
   // ex. -n 10 for FAST mode, -b 1000 for nonparametric bootstrap, -B 1000 for Ultrafast bs)
+  // you can also sneak other iq-tree commands in here like --keep-ident, etc.
   bootstrap = "-n 10"
 
   //nucleotide substitution model to use during IQ-TREE build

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,6 +36,9 @@ params {
   // ex. -n 10 for FAST mode, -b 1000 for nonparametric bootstrap, -B 1000 for Ultrafast bs)
   bootstrap = "-n 10"
 
+  //nucleotide substitution model to use during IQ-TREE build
+  sub_model = "GTR+I+R"
+
   //input sequences
   seqs = "${params.work_dir}/data/sequences.fasta"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,7 +4,7 @@ manifest {
   homePage = 'https://github.com/j3551ca/fluflo'
   description = 'Phylogenetics in Nextflow'
   mainScript = 'main.nf'
-  version = '0.1.3'
+  version = '0.2.0'
 }
 
 //pipeline parameters


### PR DESCRIPTION
Handles the case where *.contree (consensus of bootstrap trees) is present and uses this, otherwise use the default *.treefile. Includes substitution model parameter that can be adjusted. Fixes #13 .